### PR TITLE
feat: implement StoreBlob function to store files as blobs using SHA-256

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,0 +1,3 @@
+module example/hello
+
+go 1.25.1

--- a/src/internal/main.go
+++ b/src/internal/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+
+// StoreBlob stores a file as a blob in the specified directory using its SHA-256 hash as the filename.
+// It returns the blob ID (the hex-encoded hash) and an error, if any.
+// If the blob already exists in the store directory, it does not overwrite it.
+// Parameters:
+//   - filePath: the path to the source file to be stored.
+//   - storeDir: the directory where the blob should be stored.
+// Returns:
+//   - string: the blob ID (SHA-256 hash of the file contents).
+//   - error: any error encountered during the operation.
+func StoreBlob(filePath string, storeDir string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+	blobID := hex.EncodeToString(hash.Sum(nil))
+
+	destPath := filepath.Join(storeDir, blobID)
+	if _, err := os.Stat(destPath); err == nil {
+		return blobID, nil
+	}
+
+	file.Seek(0, 0) 
+	destFile, err := os.Create(destPath)
+	if err != nil {
+		return "", err
+	}
+	defer destFile.Close()
+
+	if _, err := io.Copy(destFile, file); err != nil {
+		return "", err
+	}
+
+	return blobID, nil
+}
+
+func main() {
+	storeDir := "./store"
+	os.MkdirAll(storeDir, 0755)
+
+    // Example file to store
+	filePath := "example.txt"
+
+	blobID, err := StoreBlob(filePath, storeDir)
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Println("File stored as:", blobID)
+	fmt.Println("Path in store:", filepath.Join(storeDir, blobID))
+}


### PR DESCRIPTION
This pull request introduces a new Go module and adds an initial implementation for storing files as content-addressed blobs using their SHA-256 hash. The key changes establish the project structure and provide a working example of file storage.

Project setup:

* Added a new Go module by creating `src/go.mod` and specifying Go version 1.25.1.

Blob storage functionality:

* Implemented the `StoreBlob` function in `src/internal/main.go`, which computes the SHA-256 hash of a file, saves it under its hash in a specified directory, and avoids overwriting existing blobs.
* Added a basic `main` function in `src/internal/main.go` that demonstrates storing an example file and prints the resulting blob ID and storage path.