### PR TITLE
adding dockerfiles to server and client

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+bin/
+.git/
+*.log
+*.tmp
+**/.DS_Store

--- a/cmd/cli-server/dockerfile
+++ b/cmd/cli-server/dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM golang:1.25-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /app/tbfs-api ./cmd/cli-server
+
+# Runtime stage
+FROM gcr.io/distroless/base-debian12
+COPY --from=builder /app/tbfs-api /usr/local/bin/tbfs-api
+WORKDIR /data
+EXPOSE 8080
+USER nonroot:nonroot
+CMD ["tbfs-api"]

--- a/cmd/cli/dockerfile
+++ b/cmd/cli/dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /app/tbfs-cli ./cmd/cli
+
+FROM gcr.io/distroless/base-debian12
+COPY --from=builder /app/tbfs-cli /usr/local/bin/tbfs-cli
+WORKDIR /work
+USER nonroot:nonroot
+ENTRYPOINT ["tbfs-cli"]


### PR DESCRIPTION
This pull request introduces Docker support for both the CLI server and CLI client components, enabling containerized builds and deployments. It adds Dockerfiles for each component with multi-stage builds for efficient image creation, and a `.dockerignore` file to optimize build contexts.

**Docker support and containerization:**

* Added a `.dockerignore` file to exclude unnecessary files and directories (such as `bin/`, `.git/`, logs, temp files, and `.DS_Store`) from Docker build contexts, reducing image size and build time.
* Introduced a multi-stage Dockerfile for the CLI server (`cmd/cli-server/dockerfile`), building the Go binary in an Alpine-based builder image and running it in a minimal distroless container for production use.
* Added a multi-stage Dockerfile for the CLI client (`cmd/cli/dockerfile`), following the same pattern as the server: building with Go in an Alpine-based image and running in a distroless container.