### PR TITLE
config: hardcoded api urls removed, docker swarm instructions

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -11,7 +11,14 @@ import (
 	"strings"
 )
 
-const serverURL = "http://localhost:8080"
+var serverURL string
+
+func init() {
+	serverURL = os.Getenv("REDCLOUD_SERVER_URL")
+	if serverURL == "" {
+		serverURL = "http://localhost:8080"
+	}
+}
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
This pull request introduces a change to how the CLI determines the server URL it connects to. Instead of always using the default URL, the CLI now checks for a `REDCLOUD_SERVER_URL` environment variable and uses it if set, falling back to the default otherwise.

Configuration improvements:

* Updated `cmd/cli/main.go` to allow the server URL to be set via the `REDCLOUD_SERVER_URL` environment variable, improving flexibility for different deployment environments. If the variable is not set, it defaults to `http://localhost:8080`.