### PR TITLE
Dev

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -11,7 +11,14 @@ import (
 	"strings"
 )
 
-const serverURL = "http://localhost:8080"
+var serverURL string
+
+func init() {
+	serverURL = os.Getenv("REDCLOUD_SERVER_URL")
+	if serverURL == "" {
+		serverURL = "http://localhost:8080"
+	}
+}
 
 func main() {
 	if len(os.Args) < 2 {


### PR DESCRIPTION
This pull request updates how the CLI determines the server URL by allowing it to be set via an environment variable, with a fallback to the default value. This change makes it easier to configure the CLI for different environments without modifying the code.

Configuration improvements:

* The `serverURL` is now initialized from the `REDCLOUD_SERVER_URL` environment variable if it is set; otherwise, it defaults to `"http://localhost:8080"` (`cmd/cli/main.go`).