### PR TITLE
ui: add RedCloud ASCII logo and update UI colors to git-style red-orange

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1,5 +1,7 @@
 """CLI entry point: REPL with prompt_toolkit."""
 
+import os
+import sys
 from prompt_toolkit import PromptSession
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.history import InMemoryHistory
@@ -26,7 +28,7 @@ COMMANDS = ["add", "delete", "list", "add-tags", "delete-tags", "exit", "help"]
 
 STYLE = Style.from_dict(
     {
-        "prompt": "#00aa00 bold",
+        "prompt": "#F45935 bold",
         "command": "#0088ff bold",
     }
 )
@@ -48,6 +50,32 @@ Examples:
   add-tags important -- urgent
   delete-tags work urgent -- archived
   delete archived"""
+
+
+def clear_screen() -> None:
+    """Clear the terminal screen (cross-platform)."""
+    if sys.platform == "win32":
+        os.system("cls")
+    else:
+        os.system("clear")
+
+
+def show_logo() -> None:
+    """Display RedCloud logo with ANSI colors."""
+    # ANSI color codes: \033[38;2;R;G;Bm for RGB colors
+    # Git-like red-orange: RGB(244, 89, 53) or #F45935
+    RED_ORANGE = "\033[38;2;244;89;53m"
+    RESET = "\033[0m"
+
+    logo = f"""{RED_ORANGE}
+ ██████╗ ███████╗██████╗  ██████╗██╗      ██████╗ ██╗   ██╗██████╗      ██████╗██╗     ██╗
+ ██╔══██╗██╔════╝██╔══██╗██╔════╝██║     ██╔═══██╗██║   ██║██╔══██╗    ██╔════╝██║     ██║
+ ██████╔╝█████╗  ██║  ██║██║     ██║     ██║   ██║██║   ██║██║  ██║    ██║     ██║     ██║
+ ██╔══██╗██╔══╝  ██║  ██║██║     ██║     ██║   ██║██║   ██║██║  ██║    ██║     ██║     ██║
+ ██║  ██║███████╗██████╔╝╚██████╗███████╗╚██████╔╝╚██████╔╝██████╔╝    ╚██████╗███████╗██║
+ ╚═╝  ╚═╝╚══════╝╚═════╝  ╚═════╝╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝      ╚═════╝╚══════╝╚═╝
+{RESET}"""
+    print(logo)
 
 
 def dispatch_command(cmd_obj) -> str:
@@ -74,6 +102,8 @@ def repl_loop() -> None:
         completer=completer, history=history, style=STYLE
     )
 
+    clear_screen()
+    show_logo()
     print("RedCloud CLI - Tag-based File System")
     print("Type 'help' for commands or 'exit' to quit.\n")
 


### PR DESCRIPTION
This pull request enhances the user experience of the CLI by introducing a visually appealing colored logo and updating the prompt color to better match the application's branding. It also adds a cross-platform function to clear the terminal screen before displaying the logo and welcome message.

User interface improvements:

* Added a `clear_screen` function to clear the terminal screen on both Windows and Unix-like systems, and updated the REPL to clear the screen before startup. [[1]](diffhunk://#diff-f1a3143ac572c407bccfda90d4f16be178fd07c9d9155aca4342cb403084edcfR3-R4) [[2]](diffhunk://#diff-f1a3143ac572c407bccfda90d4f16be178fd07c9d9155aca4342cb403084edcfR55-R80) [[3]](diffhunk://#diff-f1a3143ac572c407bccfda90d4f16be178fd07c9d9155aca4342cb403084edcfR105-R106)
* Introduced a `show_logo` function that displays a colored ASCII art logo using ANSI escape codes, shown at the start of the REPL session. [[1]](diffhunk://#diff-f1a3143ac572c407bccfda90d4f16be178fd07c9d9155aca4342cb403084edcfR55-R80) [[2]](diffhunk://#diff-f1a3143ac572c407bccfda90d4f16be178fd07c9d9155aca4342cb403084edcfR105-R106)
* Changed the prompt color in the `STYLE` dictionary to a red-orange shade (`#F45935`) to match the new branding.