### PR TITLE
feat: add clear command to REPL for screen refresh

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -24,7 +24,7 @@ from cli.models import (
 )
 
 
-COMMANDS = ["add", "delete", "list", "add-tags", "delete-tags", "exit", "help"]
+COMMANDS = ["add", "delete", "list", "add-tags", "delete-tags", "clear", "exit", "help"]
 
 STYLE = Style.from_dict(
     {
@@ -39,6 +39,7 @@ HELP_TEXT = """Available commands:
   list tag-query               List files matching tag query (empty = all)
   add-tags tag-query tag-list  Add tags to files matching tag query
   delete-tags tag-query tag-list  Remove tags from files matching tag query
+  clear                        Clear screen and redisplay welcome message
   help                         Show this help
   exit                         Exit REPL
 
@@ -120,6 +121,13 @@ def repl_loop() -> None:
 
             if user_input.strip() == "help":
                 print(HELP_TEXT)
+                continue
+
+            if user_input.strip() == "clear":
+                clear_screen()
+                show_logo()
+                print("RedCloud CLI - Tag-based File System")
+                print("Type 'help' for commands or 'exit' to quit.\n")
                 continue
 
             cmd_obj = parse_command(user_input)


### PR DESCRIPTION
This pull request adds a new "clear" command to the CLI, allowing users to clear the screen and redisplay the welcome message. This improves usability by making it easier for users to reset the interface during a session. The help message and command list are updated accordingly.

Enhancements to CLI commands:

* Added "clear" to the `COMMANDS` list in `cli/main.py` to support clearing the screen.
* Updated the help text to document the new "clear" command.
* Implemented handling of the "clear" command in the `repl_loop()` function, calling `clear_screen()` and redisplaying the welcome message.