### PR TITLE
refactor: separate common types from role-specific types and fix CHUNK_SIZE_BYTES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,6 @@ __marimo__/
 # Specific Guidance for LLM consults
 centralized/
 distributed/
+
+# Data folder
+data/

--- a/common/constants.py
+++ b/common/constants.py
@@ -1,4 +1,4 @@
 """Project-wide constants (e.g., CHUNK_SIZE, default ports)."""
 
-CHUNK_SIZE_BYTES: int = 64 * 1024 * 1024  # 64 MiB default chunk size
+CHUNK_SIZE_BYTES: int = 4 * 1024 * 1024
 # TODO: Define network ports, timeouts, protocol versions.

--- a/common/types.py
+++ b/common/types.py
@@ -1,8 +1,6 @@
-"""Shared data type definitions (FileMeta, ChunkDescriptor, ChunkRecord, etc.)."""
+"""Shared data type definitions (ChunkDescriptor, etc.)."""
 
 from dataclasses import dataclass
-from datetime import datetime
-from typing import List
 
 
 @dataclass(frozen=True)
@@ -14,16 +12,3 @@ class ChunkDescriptor:
     chunk_index: int
     size: int
     checksum: str
-
-
-@dataclass(frozen=True)
-class FileMetadata:
-    """
-    Complete metadata for a file in the system.
-    """
-    file_id: str
-    name: str
-    size: int
-    tags: List[str]
-    owner_id: str
-    created_at: datetime

--- a/controller/config.py
+++ b/controller/config.py
@@ -1,6 +1,7 @@
 """Configuration settings for the Controller server."""
 
 import os
+from common.constants import CHUNK_SIZE_BYTES
 
 
 DATABASE_PATH = os.environ.get("DFS_DATABASE_PATH", "./data/metadata.db")
@@ -8,8 +9,6 @@ DATABASE_PATH = os.environ.get("DFS_DATABASE_PATH", "./data/metadata.db")
 CONTROLLER_HOST = os.environ.get("DFS_CONTROLLER_HOST", "0.0.0.0")
 
 CONTROLLER_PORT = int(os.environ.get("DFS_CONTROLLER_PORT", "8000"))
-
-CHUNK_SIZE_BYTES = 4 * 1024 * 1024
 
 API_KEY_PREFIX = "dfs_"
 

--- a/controller/types.py
+++ b/controller/types.py
@@ -1,0 +1,18 @@
+"""Controller-specific data type definitions."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+
+@dataclass(frozen=True)
+class FileMetadata:
+    """
+    Complete metadata for a file in the system.
+    """
+    file_id: str
+    name: str
+    size: int
+    tags: List[str]
+    owner_id: str
+    created_at: datetime


### PR DESCRIPTION
This pull request refactors how shared data types and constants are organized, improves code clarity, and ensures better separation of concerns between modules. The most notable changes are the relocation of the `FileMetadata` type to the controller module and the centralization of the chunk size constant.

### Refactoring and organization of shared types

* Removed the `FileMetadata` data class from `common/types.py` and moved it to a new `controller/types.py` file, so that file metadata is now defined only in the controller module. (`[[1]](diffhunk://#diff-5645e676af58834c193d3dfc5c47c1a3fcf1ece499beea0e9c0e8702bbc12debL17-L29)`, `[[2]](diffhunk://#diff-77a6b37967e73fea9b3f9b3b996242de969b693777a84abf9536b38caf96b3b3R1-R18)`)
* Updated the module docstring in `common/types.py` to reflect the removal of `FileMeta` and other types. (`[common/types.pyL1-L5](diffhunk://#diff-5645e676af58834c193d3dfc5c47c1a3fcf1ece499beea0e9c0e8702bbc12debL1-L5)`)

### Centralization of constants

* Changed the default value of `CHUNK_SIZE_BYTES` in `common/constants.py` from 64 MiB to 4 MiB, making this value consistent across the project. (`[common/constants.pyL3-R3](diffhunk://#diff-334da9468c65240bbd05064220845acda06d564816970656d941c77817f583d9L3-R3)`)
* Updated `controller/config.py` to import `CHUNK_SIZE_BYTES` from `common/constants.py` instead of defining it locally, ensuring a single source of truth for this constant. (`[[1]](diffhunk://#diff-b2249fb7fbf894fa460da85240a4866bc3a1590f0e766baff72e3b8b19284ce4R4)`, `[[2]](diffhunk://#diff-b2249fb7fbf894fa460da85240a4866bc3a1590f0e766baff72e3b8b19284ce4L12-L13)`)