### PR TITLE
refactor: reorganize controller structure with domain/, routes/, and schemas/ folders

### DIFF
--- a/controller/api/__init__.py
+++ b/controller/api/__init__.py
@@ -1,1 +1,0 @@
-"""API routes package."""

--- a/controller/domain/__init__.py
+++ b/controller/domain/__init__.py
@@ -1,0 +1,5 @@
+"""Domain models package."""
+
+from controller.domain.models import FileMetadata
+
+__all__ = ["FileMetadata"]

--- a/controller/domain/models.py
+++ b/controller/domain/models.py
@@ -1,4 +1,4 @@
-"""Controller-specific data type definitions."""
+"""Domain models for business logic."""
 
 from dataclasses import dataclass
 from datetime import datetime

--- a/controller/main.py
+++ b/controller/main.py
@@ -6,8 +6,8 @@ from fastapi.responses import JSONResponse
 
 from controller.config import CONTROLLER_HOST, CONTROLLER_PORT
 from controller.database import init_database
-from controller.api.auth_routes import router as auth_router
-from controller.api.file_routes import router as file_router
+from controller.routes.auth_routes import router as auth_router
+from controller.routes.file_routes import router as file_router
 from controller.exceptions import (
     DFSException,
     UserAlreadyExistsError,

--- a/controller/models/__init__.py
+++ b/controller/models/__init__.py
@@ -1,1 +1,0 @@
-"""API models package."""

--- a/controller/routes/__init__.py
+++ b/controller/routes/__init__.py
@@ -1,0 +1,6 @@
+"""API routes package."""
+
+from controller.routes.auth_routes import router as auth_router
+from controller.routes.file_routes import router as file_router
+
+__all__ = ["auth_router", "file_router"]

--- a/controller/routes/auth_routes.py
+++ b/controller/routes/auth_routes.py
@@ -2,7 +2,7 @@
 
 from fastapi import APIRouter, status
 
-from controller.models.api_models import (
+from controller.schemas.auth import (
     RegisterRequest,
     RegisterResponse,
     LoginRequest,

--- a/controller/routes/file_routes.py
+++ b/controller/routes/file_routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, File, Form, Query, UploadFile, status
 from fastapi.responses import StreamingResponse
 
 from controller.auth import get_current_user
-from controller.models.api_models import (
+from controller.schemas.files import (
     AddFileResponse,
     ListFilesResponse,
     DeleteFilesResponse,

--- a/controller/schemas/__init__.py
+++ b/controller/schemas/__init__.py
@@ -1,0 +1,35 @@
+"""Pydantic schemas for API requests and responses."""
+
+from controller.schemas.auth import (
+    RegisterRequest,
+    RegisterResponse,
+    LoginRequest,
+    LoginResponse
+)
+from controller.schemas.files import (
+    AddFileResponse,
+    FileMetadataResponse,
+    ListFilesResponse,
+    DeleteFilesResponse,
+    AddTagsRequest,
+    AddTagsResponse,
+    DeleteTagsRequest,
+    DeleteTagsResponse
+)
+from controller.schemas.common import ErrorResponse
+
+__all__ = [
+    "RegisterRequest",
+    "RegisterResponse",
+    "LoginRequest",
+    "LoginResponse",
+    "AddFileResponse",
+    "FileMetadataResponse",
+    "ListFilesResponse",
+    "DeleteFilesResponse",
+    "AddTagsRequest",
+    "AddTagsResponse",
+    "DeleteTagsRequest",
+    "DeleteTagsResponse",
+    "ErrorResponse"
+]

--- a/controller/schemas/auth.py
+++ b/controller/schemas/auth.py
@@ -1,0 +1,26 @@
+"""Pydantic schemas for authentication endpoints."""
+
+from pydantic import BaseModel
+
+
+class RegisterRequest(BaseModel):
+    """Request model for user registration."""
+    username: str
+    password: str
+
+
+class RegisterResponse(BaseModel):
+    """Response model for user registration."""
+    api_key: str
+    user_id: str
+
+
+class LoginRequest(BaseModel):
+    """Request model for user login."""
+    username: str
+    password: str
+
+
+class LoginResponse(BaseModel):
+    """Response model for user login."""
+    api_key: str

--- a/controller/schemas/common.py
+++ b/controller/schemas/common.py
@@ -1,0 +1,9 @@
+"""Common schemas used across multiple endpoints."""
+
+from pydantic import BaseModel
+
+
+class ErrorResponse(BaseModel):
+    """Response model for errors."""
+    detail: str
+    code: str

--- a/controller/schemas/files.py
+++ b/controller/schemas/files.py
@@ -1,30 +1,7 @@
-"""Pydantic models for API requests and responses."""
+"""Pydantic schemas for file operation endpoints."""
 
 from typing import List
 from pydantic import BaseModel
-
-
-class RegisterRequest(BaseModel):
-    """Request model for user registration."""
-    username: str
-    password: str
-
-
-class RegisterResponse(BaseModel):
-    """Response model for user registration."""
-    api_key: str
-    user_id: str
-
-
-class LoginRequest(BaseModel):
-    """Request model for user login."""
-    username: str
-    password: str
-
-
-class LoginResponse(BaseModel):
-    """Response model for user login."""
-    api_key: str
 
 
 class AddFileResponse(BaseModel):
@@ -78,9 +55,3 @@ class DeleteTagsResponse(BaseModel):
     """Response model for deleting tags."""
     updated_count: int
     file_ids: List[str]
-
-
-class ErrorResponse(BaseModel):
-    """Response model for errors."""
-    detail: str
-    code: str

--- a/controller/services/file_service.py
+++ b/controller/services/file_service.py
@@ -9,7 +9,7 @@ from controller.repositories.tag_repository import TagRepository
 from controller.repositories.chunk_repository import ChunkRepository, Chunk
 from controller.database import get_db_connection
 from controller.exceptions import FileNotFoundError, UnauthorizedAccessError
-from controller.types import FileMetadata
+from controller.domain import FileMetadata
 from common.types import ChunkDescriptor
 from common.constants import CHUNK_SIZE_BYTES
 

--- a/controller/services/tag_service.py
+++ b/controller/services/tag_service.py
@@ -5,7 +5,7 @@ from typing import List
 from controller.repositories.file_repository import FileRepository
 from controller.repositories.tag_repository import TagRepository
 from controller.database import get_db_connection
-from controller.types import FileMetadata
+from controller.domain import FileMetadata
 from controller.exceptions import InvalidTagQueryError
 
 


### PR DESCRIPTION
This pull request refactors the codebase to improve organization and clarity by separating domain models, API routes, and schemas into dedicated modules and packages. It also introduces new Pydantic schema files for authentication, file operations, and common responses, and updates imports throughout the codebase to reflect these changes.

**Codebase organization and module separation:**

* Created a new `controller/domain` package for business logic models, moving `FileMetadata` from `controller/types.py` (now `controller/domain/models.py`) and updating imports in services accordingly. [[1]](diffhunk://#diff-2444ed9ac17aed33964f524e1388d7f2d12b2c7bfc361bc3c030238eb98fd61bL1-R1) [[2]](diffhunk://#diff-1d389214844b6eab5155ff6efcd7e9cfe0a59cf6e7db8bd459530dfa47fae428L12-R12) [[3]](diffhunk://#diff-13a80925941227b303f2114af6568cefaf7147167d94ac8b223431cb9543d6e8L8-R8) [[4]](diffhunk://#diff-da2b21447f30195c69504beb07001b1064a59bbc8f1f37e6ff79dbe35213a5ceR1-R5)
* Established a dedicated `controller/routes` package for API route definitions, moving route files from `controller/api` and updating their imports in `controller/main.py`. Added a central `__init__.py` for route aggregation. [[1]](diffhunk://#diff-8c81a3b24232411a20108cd0a3115c771b8c25428f9185d55ee0a2ccedc5a1d4L9-R10) [[2]](diffhunk://#diff-6974679f5200c59e46f37009eb97a51696365e101f9c5411d1237250f8242d06R1-R6) [[3]](diffhunk://#diff-b29b397f33b8be2c8e16d798ca6b4896c981284b8c244138d74dcfc6810de656L5-R5) [[4]](diffhunk://#diff-61634970dffe5b5fc6edb08ed51fde5ed983c104a5849f9cc53d3c9c7d978151L7-R7)

**Schema definition and usage:**

* Introduced a new `controller/schemas` package for Pydantic models, splitting authentication, file operations, and common error responses into separate modules (`auth.py`, `files.py`, `common.py`). Updated route files to import schemas from these new locations. [[1]](diffhunk://#diff-366586d0324ce81a34c4478dadea3d6b83b1b70d9677e8f4f61089d5d0055d47R1-R35) [[2]](diffhunk://#diff-77471bbd14dfa34422b594a2f291591a58a1882020bfba57d9d81ba2d36fd6bcR1-R26) [[3]](diffhunk://#diff-ec21e524a466aa6e4a2b7211c58ee0fbabff599903d994c1a4a8256c38b5a054R1-R9) [[4]](diffhunk://#diff-5867c127ba5ad22d629a738f7f46a07de82686cdcb7e4809057f7f1bdf8d0c46L1-L29) [[5]](diffhunk://#diff-5867c127ba5ad22d629a738f7f46a07de82686cdcb7e4809057f7f1bdf8d0c46L81-L86) [[6]](diffhunk://#diff-b29b397f33b8be2c8e16d798ca6b4896c981284b8c244138d74dcfc6810de656L5-R5) [[7]](diffhunk://#diff-61634970dffe5b5fc6edb08ed51fde5ed983c104a5849f9cc53d3c9c7d978151L7-R7)

**Documentation and cleanup:**

* Updated or added module-level docstrings to clarify the purpose of each package, and removed outdated or misplaced docstrings from previous locations. [[1]](diffhunk://#diff-5d6114839722c02441ef5bc20a196d1c96225c265459a6fe2303642bfbab6b2fL1) [[2]](diffhunk://#diff-b58a6ff0576cfedf63683983ad20ceae21972327163c2fc65bac484943578ec9L1) [[3]](diffhunk://#diff-da2b21447f30195c69504beb07001b1064a59bbc8f1f37e6ff79dbe35213a5ceR1-R5) [[4]](diffhunk://#diff-6974679f5200c59e46f37009eb97a51696365e101f9c5411d1237250f8242d06R1-R6) [[5]](diffhunk://#diff-366586d0324ce81a34c4478dadea3d6b83b1b70d9677e8f4f61089d5d0055d47R1-R35) [[6]](diffhunk://#diff-77471bbd14dfa34422b594a2f291591a58a1882020bfba57d9d81ba2d36fd6bcR1-R26) [[7]](diffhunk://#diff-ec21e524a466aa6e4a2b7211c58ee0fbabff599903d994c1a4a8256c38b5a054R1-R9) [[8]](diffhunk://#diff-5867c127ba5ad22d629a738f7f46a07de82686cdcb7e4809057f7f1bdf8d0c46L1-L29)

**File renaming and structure:**

* Renamed files for consistency with new package structure: `controller/types.py` → `controller/domain/models.py`, `controller/api/auth_routes.py` → `controller/routes/auth_routes.py`, `controller/api/file_routes.py` → `controller/routes/file_routes.py`, `controller/models/api_models.py` → `controller/schemas/files.py`. [[1]](diffhunk://#diff-2444ed9ac17aed33964f524e1388d7f2d12b2c7bfc361bc3c030238eb98fd61bL1-R1) [[2]](diffhunk://#diff-b29b397f33b8be2c8e16d798ca6b4896c981284b8c244138d74dcfc6810de656L5-R5) [[3]](diffhunk://#diff-61634970dffe5b5fc6edb08ed51fde5ed983c104a5849f9cc53d3c9c7d978151L7-R7) [[4]](diffhunk://#diff-5867c127ba5ad22d629a738f7f46a07de82686cdcb7e4809057f7f1bdf8d0c46L1-L29)

**Import updates:**

* Updated all relevant imports across the codebase to use the new module paths and reflect the reorganized structure. [[1]](diffhunk://#diff-8c81a3b24232411a20108cd0a3115c771b8c25428f9185d55ee0a2ccedc5a1d4L9-R10) [[2]](diffhunk://#diff-b29b397f33b8be2c8e16d798ca6b4896c981284b8c244138d74dcfc6810de656L5-R5) [[3]](diffhunk://#diff-61634970dffe5b5fc6edb08ed51fde5ed983c104a5849f9cc53d3c9c7d978151L7-R7) [[4]](diffhunk://#diff-1d389214844b6eab5155ff6efcd7e9cfe0a59cf6e7db8bd459530dfa47fae428L12-R12) [[5]](diffhunk://#diff-13a80925941227b303f2114af6568cefaf7147167d94ac8b223431cb9543d6e8L8-R8)