### PR TITLE
fix: prevent deletion of all tags by introducing checks and handling skipped files

### DIFF
--- a/cli/controller_client.py
+++ b/cli/controller_client.py
@@ -450,13 +450,26 @@ class ControllerClient:
                 data = response.json()
                 updated_count = data['updated_count']
                 file_ids = data['file_ids']
+                skipped_files = data.get('skipped_files', [])
 
-                if updated_count == 0:
+                if updated_count == 0 and len(skipped_files) == 0:
                     return "No files updated. No files matched the query."
 
-                tags_str = ', '.join(tags_to_remove)
-                file_ids_str = ', '.join([fid[:8] + '...' for fid in file_ids])
-                return f"Removed tags [{tags_str}] from {updated_count} file(s).\nFile IDs: {file_ids_str}"
+                output = []
+                
+                if updated_count > 0:
+                    tags_str = ', '.join(tags_to_remove)
+                    file_ids_str = ', '.join([fid[:8] + '...' for fid in file_ids])
+                    output.append(f"Removed tags [{tags_str}] from {updated_count} file(s).")
+                    output.append(f"File IDs: {file_ids_str}")
+                
+                if skipped_files:
+                    output.append("\nSkipped files (would become tagless):")
+                    for skip in skipped_files:
+                        output.append(f"  - {skip['name']} (ID: {skip['file_id'][:8]}...)")
+                        output.append(f"    Current tags: {', '.join(skip['current_tags'])}")
+                
+                return '\n'.join(output)
             else:
                 return f"Error: {self._format_error(response)}"
 

--- a/controller/exceptions.py
+++ b/controller/exceptions.py
@@ -50,6 +50,13 @@ class ChunkserverUnavailableError(DFSException):
     pass
 
 
+class EmptyTagListError(DFSException):
+    """
+    Raised when attempting to create or update a file with an empty tag list.
+    """
+    pass
+
+
 class InvalidTagQueryError(DFSException):
     """
     Raised when a tag query is malformed or invalid.

--- a/controller/schemas/files.py
+++ b/controller/schemas/files.py
@@ -52,7 +52,15 @@ class DeleteTagsRequest(BaseModel):
     tags_to_remove: List[str]
 
 
+class SkippedFileInfo(BaseModel):
+    """Information about a file skipped during tag deletion."""
+    file_id: str
+    name: str
+    current_tags: List[str]
+
+
 class DeleteTagsResponse(BaseModel):
     """Response model for deleting tags."""
     updated_count: int
     file_ids: List[str]
+    skipped_files: List[SkippedFileInfo] = []

--- a/controller/services/file_service.py
+++ b/controller/services/file_service.py
@@ -12,7 +12,7 @@ from controller.repositories.file_repository import FileRepository, File
 from controller.repositories.tag_repository import TagRepository
 from controller.repositories.chunk_repository import ChunkRepository, Chunk
 from controller.database import get_db_connection
-from controller.exceptions import FileNotFoundError, UnauthorizedAccessError
+from controller.exceptions import FileNotFoundError, UnauthorizedAccessError, EmptyTagListError
 from controller.domain import FileMetadata
 from controller.chunkserver_client import ChunkserverClient
 from common.types import ChunkDescriptor
@@ -36,6 +36,9 @@ class FileService:
         tags: List[str],
         owner_id: str,
     ) -> FileMetadata:
+        if not tags:
+            raise EmptyTagListError("At least one tag is required for file upload")
+        
         from controller.utils import generate_uuid
         
         file_id = generate_uuid()


### PR DESCRIPTION
This pull request introduces robust handling for file tags, ensuring that files cannot be left without any tags and improving user feedback during tag deletion. The main changes include enforcing at least one tag on file uploads, preventing tag deletions that would leave files tagless, and providing detailed information about skipped files during tag removal operations.

**Tag Deletion Safety and Feedback:**

- Added logic to prevent removal of tags from files if it would result in the file having zero tags. Such files are now skipped during deletion, and detailed information about these skipped files is returned in the API response. (`controller/services/tag_service.py` [[1]](diffhunk://#diff-13a80925941227b303f2114af6568cefaf7147167d94ac8b223431cb9543d6e8L56-R101) `controller/repositories/tag_repository.py` [[2]](diffhunk://#diff-41986e5eaffe30923e17a51b4258ff2fad2d00cdf4bbcd858c87ff8df8bc83fdR42-R79) `controller/schemas/files.py` [[3]](diffhunk://#diff-5867c127ba5ad22d629a738f7f46a07de82686cdcb7e4809057f7f1bdf8d0c46R55-R66) `controller/routes/file_routes.py` [[4]](diffhunk://#diff-61634970dffe5b5fc6edb08ed51fde5ed983c104a5849f9cc53d3c9c7d978151R249) [[5]](diffhunk://#diff-61634970dffe5b5fc6edb08ed51fde5ed983c104a5849f9cc53d3c9c7d978151L251-R259) [[6]](diffhunk://#diff-61634970dffe5b5fc6edb08ed51fde5ed983c104a5849f9cc53d3c9c7d978151R268) `cli/controller_client.py` [[7]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1R453-R472)

- The CLI and API response for tag deletion now include a list of skipped files that would have become tagless, displaying their names, IDs, and current tags for transparency. (`cli/controller_client.py` [[1]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1R453-R472) `controller/schemas/files.py` [[2]](diffhunk://#diff-5867c127ba5ad22d629a738f7f46a07de82686cdcb7e4809057f7f1bdf8d0c46R55-R66)

**Tag Requirement Enforcement:**

- Enforced that at least one tag is required when uploading a file, both at the API route and service layer. If no tags are provided, a clear error is returned to the user. (`controller/routes/file_routes.py` [[1]](diffhunk://#diff-61634970dffe5b5fc6edb08ed51fde5ed983c104a5849f9cc53d3c9c7d978151R55-R60) `controller/services/file_service.py` [[2]](diffhunk://#diff-1d389214844b6eab5155ff6efcd7e9cfe0a59cf6e7db8bd459530dfa47fae428R39-R41) `controller/exceptions.py` [[3]](diffhunk://#diff-b7a603b9c5cd710326600e395927ff92deb82b65a129f5814bb9559b3c910824R53-R59) [[4]](diffhunk://#diff-61634970dffe5b5fc6edb08ed51fde5ed983c104a5849f9cc53d3c9c7d978151L3-R7) [[5]](diffhunk://#diff-1d389214844b6eab5155ff6efcd7e9cfe0a59cf6e7db8bd459530dfa47fae428L15-R15)

**Supporting Changes:**

- Introduced a new exception `EmptyTagListError` for attempts to create or update a file with an empty tag list. (`controller/exceptions.py` [[1]](diffhunk://#diff-b7a603b9c5cd710326600e395927ff92deb82b65a129f5814bb9559b3c910824R53-R59) `controller/services/file_service.py` [[2]](diffhunk://#diff-1d389214844b6eab5155ff6efcd7e9cfe0a59cf6e7db8bd459530dfa47fae428R39-R41) [[3]](diffhunk://#diff-1d389214844b6eab5155ff6efcd7e9cfe0a59cf6e7db8bd459530dfa47fae428L15-R15)
- Updated API documentation and response models to reflect the new `skipped_files` field in tag deletion responses. (`controller/routes/file_routes.py` [[1]](diffhunk://#diff-61634970dffe5b5fc6edb08ed51fde5ed983c104a5849f9cc53d3c9c7d978151R249) `controller/schemas/files.py` [[2]](diffhunk://#diff-5867c127ba5ad22d629a738f7f46a07de82686cdcb7e4809057f7f1bdf8d0c46R55-R66)

These changes collectively improve data integrity and user experience when managing file tags.