### PR TITLE
fix: improve file path handling and add CLI deployment scripts

### DIFF
--- a/docker/COMMANDS.md
+++ b/docker/COMMANDS.md
@@ -1,0 +1,318 @@
+# Manual Deployment Guide for RedCloud Files
+
+Based on the Docker configuration, here's a complete step-by-step guide to manually deploy the distributed file system without using the provided scripts:
+
+## Prerequisites
+- Docker Engine 20.10 or higher installed
+- Terminal/Command Prompt with administrative privileges
+
+---
+
+## Step 1: Initialize Docker Swarm
+
+First, enable Docker Swarm mode on your machine:
+
+```bash
+docker swarm init
+```
+
+If successful, you'll see output with worker/manager join tokens. Keep these for adding additional nodes later.
+
+**Note:** If Docker Swarm is already active, skip this step.
+
+---
+
+## Step 2: Create Overlay Network
+
+Create the Docker overlay network that all services will use to communicate:
+
+```bash
+docker network create --driver overlay --attachable dfs-network
+```
+
+This creates an isolated network named `dfs-network` where all containers can discover each other using DNS aliases.
+
+---
+
+## Step 3: Build Docker Images
+
+Navigate to the project root directory and build each Docker image:
+
+### Build Controller Image:
+```bash
+docker build -f docker/Dockerfile.controller -t redcloud-controller:latest .
+```
+
+### Build Chunkserver Image:
+```bash
+docker build -f docker/Dockerfile.chunkserver -t redcloud-chunkserver:latest .
+```
+
+### Build CLI Image:
+```bash
+docker build -f docker/Dockerfile.cli -t redcloud-cli:latest .
+```
+
+**Verify images were created:**
+```bash
+docker images | findstr redcloud
+```
+
+---
+
+## Step 4: Start the Controller
+
+Launch the controller container (metadata service):
+
+```bash
+docker run -d --network dfs-network --network-alias controller redcloud-controller:latest
+```
+
+**What this does:**
+- `-d`: Runs in detached mode (background)
+- `--network dfs-network`: Connects to the overlay network
+- `--network-alias controller`: Sets DNS alias as "controller"
+- The controller will be accessible at `http://controller:8000` within the network
+
+**Optional - Get the container ID:**
+```bash
+docker ps --filter ancestor=redcloud-controller:latest
+```
+
+---
+
+## Step 5: Start Chunkserver(s)
+
+Launch one or more chunkserver containers (storage service):
+
+### Single Chunkserver:
+```bash
+docker run -d --network dfs-network --network-alias chunkserver redcloud-chunkserver:latest
+```
+
+### Multiple Chunkservers (for load balancing):
+Run the command multiple times:
+```bash
+docker run -d --network dfs-network --network-alias chunkserver redcloud-chunkserver:latest
+docker run -d --network dfs-network --network-alias chunkserver redcloud-chunkserver:latest
+docker run -d --network dfs-network --network-alias chunkserver redcloud-chunkserver:latest
+```
+
+Docker's DNS will automatically round-robin load balance requests to `chunkserver:50051` across all containers with that alias.
+
+---
+
+## Step 6: Launch the CLI
+
+The CLI requires volume mounts to access files on your host machine for uploads and downloads.
+
+### Linux / macOS
+
+Navigate to the directory containing files you want to upload:
+
+```bash
+cd /path/to/your/files
+mkdir -p downloads
+
+docker run -it --rm \
+    --network dfs-network \
+    -v "$(pwd):/uploads" \
+    -v "$(pwd)/downloads:/downloads" \
+    -w /uploads \
+    redcloud-cli:latest
+```
+
+### Windows PowerShell
+
+Navigate to the directory containing files you want to upload:
+
+```powershell
+cd C:\path\to\your\files
+if (-not (Test-Path "downloads")) { New-Item -ItemType Directory -Path "downloads" }
+
+docker run -it --rm `
+    --network dfs-network `
+    -v "${PWD}:/uploads" `
+    -v "${PWD}/downloads:/downloads" `
+    -w /uploads `
+    redcloud-cli:latest
+```
+
+### Windows Command Prompt
+
+Navigate to the directory containing files you want to upload:
+
+```cmd
+cd C:\path\to\your\files
+if not exist downloads mkdir downloads
+
+docker run -it --rm ^
+    --network dfs-network ^
+    -v "%cd%:/uploads" ^
+    -v "%cd%/downloads:/downloads" ^
+    -w /uploads ^
+    redcloud-cli:latest
+```
+
+### Volume Mounts Explained
+
+- **`/uploads`**: Your current directory is mounted here. Reference files relative to this location when uploading.
+- **`/downloads`**: Downloaded files are saved here automatically (maps to `./downloads` on your host).
+- **`-w /uploads`**: Sets the working directory inside the container.
+
+### Usage Examples
+
+Once the CLI is running:
+
+**Upload files:**
+```
+add requirements.txt [dependencies, code]
+add README.md .gitignore [docs]
+add chunkserver/main.py [python, server]
+```
+
+**Download files:**
+```
+download requirements.txt
+```
+Files are automatically saved to the `downloads/` directory on your host.
+
+**Download to custom location:**
+```
+download requirements.txt /uploads/custom-location.txt
+```
+
+### Important Notes
+
+- **File paths are relative to `/uploads`** (your mounted directory)
+- Navigate to your files directory **before** starting the CLI container
+- Downloads default to `/downloads` unless you specify a different output path
+- The container working directory is `/uploads`, so relative paths work naturally
+
+---
+
+## Verification & Testing
+
+### Check Running Containers:
+```bash
+docker ps --filter network=dfs-network
+```
+
+### Inspect Network:
+```bash
+docker network inspect dfs-network
+```
+
+### Test DNS Resolution:
+```bash
+docker run --rm --network dfs-network alpine nslookup controller
+docker run --rm --network dfs-network alpine nslookup chunkserver
+```
+
+### Health Check (from within network):
+```bash
+docker run --rm --network dfs-network curlimages/curl http://controller:8000/health
+```
+
+---
+
+## Multi-Host Deployment (Optional)
+
+To add worker nodes on different machines:
+
+### On Manager Node:
+Get the join token:
+```bash
+docker swarm join-token worker
+```
+
+### On Worker Node:
+Run the join command (replace with your values):
+```bash
+docker swarm join --token <TOKEN> <MANAGER-IP>:2377
+```
+
+Once joined, you can run chunkserver or CLI containers on any node—they'll automatically connect to the `dfs-network`.
+
+---
+
+## Management Commands
+
+### View Logs:
+```bash
+# All containers
+docker ps --filter network=dfs-network
+
+# Specific container (replace <CONTAINER_ID>)
+docker logs <CONTAINER_ID>
+docker logs -f <CONTAINER_ID>  # Follow mode
+```
+
+### Stop Containers:
+```bash
+# Stop specific container
+docker stop <CONTAINER_ID>
+
+# Stop all RedCloud containers
+docker ps --filter network=dfs-network -q | ForEach-Object { docker stop $_ }
+```
+
+### Remove Containers:
+```bash
+docker ps -a --filter network=dfs-network -q | ForEach-Object { docker rm $_ }
+```
+
+### Remove Network:
+```bash
+docker network rm dfs-network
+```
+
+### Remove Images:
+```bash
+docker rmi redcloud-controller:latest redcloud-chunkserver:latest redcloud-cli:latest
+```
+
+### Leave Swarm:
+```bash
+docker swarm leave --force
+```
+
+---
+
+## Environment Variables (Optional Customization)
+
+You can override default settings when starting containers:
+
+### Controller:
+```bash
+docker run -d --network dfs-network --network-alias controller \
+  -e DFS_DATABASE_PATH=/app/data/metadata.db \
+  -e DFS_CONTROLLER_HOST=0.0.0.0 \
+  -e DFS_CONTROLLER_PORT=8000 \
+  -e DFS_CHUNKSERVER_ADDRESS=chunkserver:50051 \
+  redcloud-controller:latest
+```
+
+### Chunkserver:
+```bash
+docker run -d --network dfs-network --network-alias chunkserver \
+  -e CHUNK_STORAGE_PATH=/app/data/chunks \
+  -e CHUNK_INDEX_PATH=/app/data/chunk_index.json \
+  redcloud-chunkserver:latest
+```
+
+### CLI:
+```bash
+docker run -it --rm --network dfs-network \
+  -e DFS_CONTROLLER_URL=http://controller:8000 \
+  redcloud-cli:latest
+```
+
+---
+
+## Important Notes
+
+- **No External Ports**: All services communicate internally. No ports are published to the host.
+- **Ephemeral Storage**: Data is stored in containers and will be lost when containers are removed.
+- **DNS-Based Discovery**: Services find each other using Docker DNS (controller, chunkserver aliases).
+- **Load Balancing**: Multiple chunkservers automatically load balance through the shared DNS alias.

--- a/docker/Dockerfile.cli
+++ b/docker/Dockerfile.cli
@@ -8,6 +8,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY common/ ./common/
 COPY cli/ ./cli/
 
+RUN mkdir -p /uploads /downloads
+
+VOLUME /uploads
+VOLUME /downloads
+
+WORKDIR /uploads
+
 ENV DFS_CONTROLLER_URL=http://controller:8000
 
 CMD ["python", "-m", "cli.main"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -54,11 +54,89 @@ Starts 3 chunkserver containers with automatic load balancing.
 
 ### 5. Run CLI
 
+Navigate to the directory containing files you want to upload, then:
+
 ```bash
 ./run-cli.sh
 ```
 
-Starts interactive CLI connected to the controller via Docker DNS.
+Starts interactive CLI with volume mounts for file uploads and downloads.
+
+For cross-platform support:
+- **Linux/macOS**: Use `run-cli.sh`
+- **Windows PowerShell**: Use `run-cli.ps1`
+
+See [COMMANDS.md](COMMANDS.md#step-6-launch-the-cli) for manual deployment options.
+
+## File Upload/Download
+
+The CLI container requires volume mounts to access files on your host machine.
+
+### Volume Mounts
+
+When starting the CLI, two directories are mounted:
+
+- **`/uploads`**: Your current working directory (for file uploads)
+- **`/downloads`**: The `./downloads` subdirectory (for file downloads)
+
+### Upload Files
+
+Navigate to the directory containing your files before starting the CLI:
+
+```bash
+cd /path/to/your/files
+./docker/scripts/run-cli.sh
+```
+
+Inside the CLI, reference files relative to your current directory:
+
+```
+add requirements.txt [dependencies]
+add README.md [docs]
+add src/main.py [code, python]
+```
+
+### Download Files
+
+Downloads are automatically saved to the `downloads/` directory:
+
+```
+download requirements.txt
+```
+
+The file will be saved to `./downloads/requirements.txt` on your host machine.
+
+### Cross-Platform Examples
+
+**Linux/macOS:**
+```bash
+cd ~/my-project
+docker run -it --rm --network dfs-network \
+    -v "$(pwd):/uploads" \
+    -v "$(pwd)/downloads:/downloads" \
+    -w /uploads \
+    redcloud-cli:latest
+```
+
+**Windows PowerShell:**
+```powershell
+cd C:\Users\YourName\my-project
+docker run -it --rm --network dfs-network `
+    -v "${PWD}:/uploads" `
+    -v "${PWD}/downloads:/downloads" `
+    -w /uploads `
+    redcloud-cli:latest
+```
+
+**Windows CMD:**
+```cmd
+cd C:\Users\YourName\my-project
+docker run -it --rm --network dfs-network ^
+    -v "%cd%:/uploads" ^
+    -v "%cd%/downloads:/downloads" ^
+    -w /uploads ^
+    redcloud-cli:latest
+```
 
 ## Multi-Host Deployment
 

--- a/docker/scripts/run-cli.ps1
+++ b/docker/scripts/run-cli.ps1
@@ -1,0 +1,19 @@
+
+Write-Host "Starting CLI container (interactive mode)..." -ForegroundColor Green
+Write-Host "Press Ctrl+D or type 'exit' to quit" -ForegroundColor Green
+Write-Host ""
+Write-Host "Volume mounts:" -ForegroundColor Yellow
+Write-Host "  - Current directory -> /uploads (for file uploads)" -ForegroundColor Yellow
+Write-Host "  - .\downloads -> /downloads (for file downloads)" -ForegroundColor Yellow
+Write-Host ""
+
+if (-not (Test-Path "downloads")) {
+    New-Item -ItemType Directory -Path "downloads" | Out-Null
+}
+
+docker run -it --rm `
+    --network dfs-network `
+    -v "${PWD}:/uploads" `
+    -v "${PWD}/downloads:/downloads" `
+    -w /uploads `
+    redcloud-cli:latest

--- a/docker/scripts/run-cli.sh
+++ b/docker/scripts/run-cli.sh
@@ -5,7 +5,16 @@ set -e
 echo "Starting CLI container (interactive mode)..."
 echo "Press Ctrl+D or type 'exit' to quit"
 echo ""
+echo "Volume mounts:"
+echo "  - Current directory -> /uploads (for file uploads)"
+echo "  - ./downloads -> /downloads (for file downloads)"
+echo ""
+
+mkdir -p downloads
 
 docker run -it --rm \
     --network dfs-network \
+    -v "$(pwd):/uploads" \
+    -v "$(pwd)/downloads:/downloads" \
+    -w /uploads \
     redcloud-cli:latest


### PR DESCRIPTION
This pull request introduces several improvements to the Docker-based deployment and CLI user experience for RedCloud Files. The main focus is on making file uploads and downloads more intuitive by using volume mounts, standardizing file paths inside the CLI container, and providing comprehensive cross-platform documentation and scripts for manual and automated deployment.

**Key changes include:**

### CLI File Handling Improvements
- The CLI now normalizes file paths using absolute paths and expands user directories (e.g., `~`) before file operations, ensuring consistent behavior regardless of how users specify file paths. (`cli/controller_client.py`)
- Downloaded files now default to being saved in the `/downloads` directory inside the container, which maps to a `downloads` folder on the host via volume mount. If no output path is specified, files are saved to this location. (`cli/controller_client.py`) [[1]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L487-R489) [[2]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1R511-R514)

### Dockerfile and Container Setup
- The CLI Dockerfile (`docker/Dockerfile.cli`) now creates `/uploads` and `/downloads` directories, declares them as volumes, and sets the working directory to `/uploads`, aligning the container's file structure with the host's for easier file access.

### Documentation Enhancements
- Added a detailed manual deployment guide (`docker/COMMANDS.md`) covering Docker Swarm setup, image building, network configuration, container launching, and cross-platform CLI usage, including volume mount explanations and troubleshooting.
- Updated the main Docker README (`docker/README.md`) to clarify file upload/download workflows, volume mount requirements, and provide explicit cross-platform examples for running the CLI.

### Cross-Platform CLI Startup Scripts
- Introduced and improved startup scripts for launching the CLI with the correct volume mounts on Linux/macOS (`docker/scripts/run-cli.sh`) and Windows PowerShell (`docker/scripts/run-cli.ps1`). These scripts ensure the `downloads` directory exists and display clear instructions about the mounted directories. [[1]](diffhunk://#diff-ea347c96d2b107dccb7129e1e05a9286c3f22f3abbddd6303de3c85b5c8df885R8-R19) [[2]](diffhunk://#diff-de7fb8fde56cb263b8a8c364f0e92691899209b46d41daf52a4ab81676e81d12R1-R19)

These changes collectively make it much easier and more reliable for users to upload and download files using the CLI in a Dockerized environment, regardless of their operating system.