### PR TITLE
fix: enhance read/write privileges for upload/download folders and improve path normalization

### DIFF
--- a/docker/COMMANDS.md
+++ b/docker/COMMANDS.md
@@ -112,7 +112,9 @@ Navigate to the directory containing files you want to upload:
 
 ```bash
 cd /path/to/your/files
+chmod 777 .
 mkdir -p downloads
+chmod 777 downloads
 
 docker run -it --rm \
     --network dfs-network \
@@ -156,8 +158,8 @@ docker run -it --rm ^
 
 ### Volume Mounts Explained
 
-- **`/uploads`**: Your current directory is mounted here. Reference files relative to this location when uploading.
-- **`/downloads`**: Downloaded files are saved here automatically (maps to `./downloads` on your host).
+- **`/uploads`**: Your current directory is mounted here. Upload paths can use `uploads/` prefix, be relative (auto-resolved to `/uploads`), or be absolute paths within this directory.
+- **`/downloads`**: Downloaded files are saved here automatically (maps to `./downloads` on your host). Download paths can use `downloads/` prefix, be relative (auto-resolved to `/downloads`), or be absolute paths.
 - **`-w /uploads`**: Sets the working directory inside the container.
 
 ### Usage Examples
@@ -167,27 +169,29 @@ Once the CLI is running:
 **Upload files:**
 ```
 add requirements.txt [dependencies, code]
-add README.md .gitignore [docs]
+add uploads/README.md uploads/.gitignore [docs]
 add chunkserver/main.py [python, server]
 ```
 
 **Download files:**
 ```
 download requirements.txt
+download requirements.txt subfolder/
+download requirements.txt downloads/subfolder/renamed.txt
 ```
 Files are automatically saved to the `downloads/` directory on your host.
 
-**Download to custom location:**
-```
-download requirements.txt /uploads/custom-location.txt
-```
-
 ### Important Notes
 
-- **File paths are relative to `/uploads`** (your mounted directory)
+- **Upload paths** can use `uploads/` prefix, be relative (resolved to `/uploads`), or be absolute paths within `/uploads`
+- **Download paths** can use `downloads/` prefix, be relative (resolved to `/downloads`), or be absolute paths within `/downloads` or `/uploads`
+- **File paths are relative** to their respective directories (`/uploads` for uploads, `/downloads` for downloads)
 - Navigate to your files directory **before** starting the CLI container
-- Downloads default to `/downloads` unless you specify a different output path
-- The container working directory is `/uploads`, so relative paths work naturally
+- Downloads default to `/downloads/{filename}` when no output path is specified
+- The container working directory is `/uploads`, so relative upload paths work naturally
+- **Path validation** prevents directory traversal attacks (e.g., `../../../etc/passwd`) and restricts file access to `/uploads` and `/downloads` directories only
+- **Wrong prefix errors**: Using `downloads/` in upload commands or `uploads/` in download commands will return a helpful error message
+- **Security boundary**: Absolute paths outside `/uploads` and `/downloads` directories are blocked for security reasons
 
 ---
 

--- a/docker/Dockerfile.cli
+++ b/docker/Dockerfile.cli
@@ -9,6 +9,7 @@ COPY common/ ./common/
 COPY cli/ ./cli/
 
 RUN mkdir -p /uploads /downloads
+RUN chmod 777 /uploads /downloads
 
 VOLUME /uploads
 VOLUME /downloads

--- a/docker/scripts/run-cli.sh
+++ b/docker/scripts/run-cli.sh
@@ -10,7 +10,9 @@ echo "  - Current directory -> /uploads (for file uploads)"
 echo "  - ./downloads -> /downloads (for file downloads)"
 echo ""
 
+chmod 777 .
 mkdir -p downloads
+chmod 777 downloads
 
 docker run -it --rm \
     --network dfs-network \


### PR DESCRIPTION
This pull request enhances file upload and download path handling in the CLI, improving security, user experience, and documentation. The main changes are the introduction of robust path normalization and validation logic in `controller_client.py`, updates to documentation to clarify path usage and security, and Dockerfile/script changes to ensure proper permissions for mounted directories.

**Path handling and security improvements:**

* Added `_normalize_upload_path` and `_normalize_download_path` methods in `controller_client.py` to standardize, validate, and restrict file paths for uploads and downloads, preventing directory traversal and enforcing boundaries to `/uploads` and `/downloads`. These methods also provide clear error messages for incorrect prefix usage or invalid paths.
* Updated the `add_files` and `download` methods to use the new normalization logic, ensuring all file operations are securely constrained and user errors are handled gracefully. [[1]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L217-R292) [[2]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L231-R310) [[3]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L489-L495) [[4]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L507-R589)

**Documentation updates:**

* Revised `docker/COMMANDS.md` to explain the new path conventions for uploads and downloads, provide usage examples with the new prefixes, and highlight security boundaries and error handling for invalid paths or prefixes. [[1]](diffhunk://#diff-71389f8624bcc002059dbac5db3bff5038bd3d09f504cf26ced4a5f50674d9daL159-R162) [[2]](diffhunk://#diff-71389f8624bcc002059dbac5db3bff5038bd3d09f504cf26ced4a5f50674d9daL170-R194)

**Docker and script improvements:**

* Set directory permissions to `777` for `/uploads` and `/downloads` in the Dockerfile and CLI run scripts to avoid permission issues when mounting host directories. [[1]](diffhunk://#diff-8289ff3d37ce81c9a662c40fad26683ed2a6b761265d61794f34dc374833394aR12) [[2]](diffhunk://#diff-ea347c96d2b107dccb7129e1e05a9286c3f22f3abbddd6303de3c85b5c8df885R13-R15) [[3]](diffhunk://#diff-71389f8624bcc002059dbac5db3bff5038bd3d09f504cf26ced4a5f50674d9daR115-R117)

These changes collectively make file operations safer, more predictable, and easier to understand for end users.