### PR TITLE
fix: enforce mandatory uploads/ and downloads/ prefixes for file paths in CLI commands and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,7 @@ distributed/
 
 # Data folder
 data/
+
+# Uploads and Downloads
+uploads/
+downloads/

--- a/cli/constants.py
+++ b/cli/constants.py
@@ -31,12 +31,12 @@ PROMPT_TEXT = "redcloud> "
 HELP_TEXT = """Available commands:
   register <username> <password>      Register new user account
   login <username> <password>         Login and get API key
-  add file-list tag-list              Add files with tags
+  add file-list tag-list              Add files with tags (files must use uploads/ prefix)
   delete tag-query                    Delete files matching tag query
   list tag-query                      List files matching tag query (empty = all)
   add-tags tag-query tag-list         Add tags to files matching tag query
   delete-tags tag-query tag-list      Remove tags from files matching tag query
-  download <filename> [output_path]   Download file by name to local path
+  download <filename> [output_path]   Download file (output uses downloads/ prefix or defaults to downloads/)
   clear                               Clear screen and redisplay welcome message
   help                                Show this help
   exit                                Exit REPL
@@ -46,11 +46,11 @@ Use '--' to separate tag-query from tag-list in add-tags/delete-tags.
 Examples:
   register alice mypassword123
   login alice mypassword123
-  add file1.txt file2.txt important work
+  add uploads/file1.txt uploads/file2.txt important work
   list important
   add-tags important -- urgent
   download document.pdf
-  download report.txt ./downloads/
+  download report.txt downloads/renamed.txt
   delete-tags work urgent -- archived
   delete archived"""
 

--- a/cli/parser.py
+++ b/cli/parser.py
@@ -69,7 +69,10 @@ def parse_command(input_line: str) -> CommandRequest:
 
 
 def _parse_add(args: list[str]) -> AddCommand:
-    """Parse 'add file-list tag-list' command."""
+    """Parse 'add file-list tag-list' command.
+    
+    Files must use uploads/ prefix (e.g., uploads/file.txt).
+    """
     if len(args) < 2:
         raise ParseError("add requires at least one file and one tag")
 
@@ -182,7 +185,11 @@ def _parse_login(args: list[str]) -> LoginCommand:
 
 
 def _parse_download(args: list[str]) -> DownloadCommand:
-    """Parse 'download <filename> [output_path]' command."""
+    """Parse 'download <filename> [output_path]' command.
+    
+    Output path must use downloads/ prefix if specified (e.g., downloads/file.txt).
+    If output_path is omitted, file is saved to downloads/{filename}.
+    """
     if len(args) < 1:
         raise ParseError("download requires at least 1 argument: <filename> [output_path]")
     

--- a/docker/COMMANDS.md
+++ b/docker/COMMANDS.md
@@ -158,8 +158,8 @@ docker run -it --rm ^
 
 ### Volume Mounts Explained
 
-- **`/uploads`**: Your current directory is mounted here. Upload paths can use `uploads/` prefix, be relative (auto-resolved to `/uploads`), or be absolute paths within this directory.
-- **`/downloads`**: Downloaded files are saved here automatically (maps to `./downloads` on your host). Download paths can use `downloads/` prefix, be relative (auto-resolved to `/downloads`), or be absolute paths.
+- **`/uploads`**: Your current directory is mounted here. Upload paths must use the `uploads/` prefix (e.g., `add uploads/file.txt [tag]`).
+- **`/downloads`**: Downloaded files are saved here. When no output path is specified, files default to `/downloads/{filename}`. When specifying an output path, it must use the `downloads/` prefix (e.g., `download file.txt downloads/output.txt`).
 - **`-w /uploads`**: Sets the working directory inside the container.
 
 ### Usage Examples
@@ -168,30 +168,31 @@ Once the CLI is running:
 
 **Upload files:**
 ```
-add requirements.txt [dependencies, code]
+add uploads/requirements.txt [dependencies, code]
 add uploads/README.md uploads/.gitignore [docs]
-add chunkserver/main.py [python, server]
+add uploads/chunkserver/main.py [python, server]
 ```
 
 **Download files:**
 ```
 download requirements.txt
-download requirements.txt subfolder/
+download requirements.txt downloads/subfolder/
 download requirements.txt downloads/subfolder/renamed.txt
 ```
 Files are automatically saved to the `downloads/` directory on your host.
+When no output path is specified, files default to downloads/{filename}.
+When specifying an output path, the downloads/ prefix is mandatory.
 
 ### Important Notes
 
-- **Upload paths** can use `uploads/` prefix, be relative (resolved to `/uploads`), or be absolute paths within `/uploads`
-- **Download paths** can use `downloads/` prefix, be relative (resolved to `/downloads`), or be absolute paths within `/downloads` or `/uploads`
-- **File paths are relative** to their respective directories (`/uploads` for uploads, `/downloads` for downloads)
+- **Upload paths** must use the `uploads/` prefix (e.g., `add uploads/file.txt [tag]`)
+- **Download paths** must use the `downloads/` prefix when specifying an output path (e.g., `download file.txt downloads/output.txt`)
+- **Default download behavior**: When no output path is specified, files are saved to `/downloads/{filename}` (no prefix needed)
 - Navigate to your files directory **before** starting the CLI container
-- Downloads default to `/downloads/{filename}` when no output path is specified
-- The container working directory is `/uploads`, so relative upload paths work naturally
-- **Path validation** prevents directory traversal attacks (e.g., `../../../etc/passwd`) and restricts file access to `/uploads` and `/downloads` directories only
-- **Wrong prefix errors**: Using `downloads/` in upload commands or `uploads/` in download commands will return a helpful error message
-- **Security boundary**: Absolute paths outside `/uploads` and `/downloads` directories are blocked for security reasons
+- The container working directory is `/uploads`, so files in subdirectories use paths like `uploads/subfolder/file.txt`
+- **Path validation** prevents directory traversal attacks and restricts file access to appropriate directories
+- **Prefix enforcement**: Upload paths without `uploads/` prefix and download output paths without `downloads/` prefix will return helpful error messages
+- **Security boundary**: Mandatory prefixes ensure uploads only read from `/uploads` and downloads only write to `/downloads`
 
 ---
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -88,12 +88,12 @@ cd /path/to/your/files
 ./docker/scripts/run-cli.sh
 ```
 
-Inside the CLI, reference files relative to your current directory:
+Inside the CLI, reference files with the mandatory uploads/ prefix:
 
 ```
-add requirements.txt [dependencies]
-add README.md [docs]
-add src/main.py [code, python]
+add uploads/requirements.txt [dependencies]
+add uploads/README.md [docs]
+add uploads/src/main.py [code, python]
 ```
 
 ### Download Files
@@ -102,9 +102,10 @@ Downloads are automatically saved to the `downloads/` directory:
 
 ```
 download requirements.txt
+download config.json downloads/backup/config.json
 ```
 
-The file will be saved to `./downloads/requirements.txt` on your host machine.
+The first command saves to `./downloads/requirements.txt`. The second command saves to `./downloads/backup/config.json` on your host machine. When specifying an output path, the downloads/ prefix is mandatory.
 
 ### Cross-Platform Examples
 


### PR DESCRIPTION
This pull request enforces stricter path prefix requirements for file upload and download commands in the CLI, updates documentation and help text to reflect these rules, and improves error messaging and security. The main goal is to require the `uploads/` prefix for all upload paths and the `downloads/` prefix for all specified download output paths, ensuring clarity and preventing accidental or insecure file access.

**Path handling enforcement and validation:**

* Upload commands now require file paths to start with the `uploads/` prefix; attempts to use other prefixes or omit the prefix result in a clear error message. Download commands require the output path (if specified) to start with the `downloads/` prefix. This is enforced in both the CLI logic and the command parser, with updated error handling for invalid paths. [[1]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L30-R33) [[2]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L42-R62) [[3]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L77-R87) [[4]](diffhunk://#diff-44598eb6145a757ef8297760299bdd63888307206e149a7ea5098e3ac41e1579L72-R75) [[5]](diffhunk://#diff-44598eb6145a757ef8297760299bdd63888307206e149a7ea5098e3ac41e1579L185-R192)

**Documentation and help text updates:**

* The CLI help text and usage examples have been updated to clearly state the new prefix requirements for uploads and downloads, including in `cli/constants.py`, `docker/COMMANDS.md`, and `docker/README.md`. Examples now consistently use the required prefixes, and explanations highlight the security and usability improvements. [[1]](diffhunk://#diff-a81f9bb0b9bf827866ceff4a9c1587d37581d7b78bcbb503ed34882cb085313eL34-R39) [[2]](diffhunk://#diff-a81f9bb0b9bf827866ceff4a9c1587d37581d7b78bcbb503ed34882cb085313eL49-R53) [[3]](diffhunk://#diff-71389f8624bcc002059dbac5db3bff5038bd3d09f504cf26ced4a5f50674d9daL161-R162) [[4]](diffhunk://#diff-71389f8624bcc002059dbac5db3bff5038bd3d09f504cf26ced4a5f50674d9daL171-R195) [[5]](diffhunk://#diff-da8fcbe728a9172b578e5d754f8e2df214c658c4321f610e63dd68bea828ab49L91-R96) [[6]](diffhunk://#diff-da8fcbe728a9172b578e5d754f8e2df214c658c4321f610e63dd68bea828ab49R105-R108)

**Security and boundary improvements:**

* The path normalization logic now strictly validates that resolved paths remain within the `/uploads` or `/downloads` directories as appropriate, preventing directory traversal and unauthorized file access. Prefix mismatches produce helpful error messages. [[1]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L42-R62) [[2]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L77-R87) [[3]](diffhunk://#diff-71389f8624bcc002059dbac5db3bff5038bd3d09f504cf26ced4a5f50674d9daL171-R195)

These changes make path handling more predictable, secure, and user-friendly for anyone using the CLI.