### PR TITLE
feat: add upload progress tracking and timeout calculation for file uploads

### DIFF
--- a/controller/routes/file_routes.py
+++ b/controller/routes/file_routes.py
@@ -59,15 +59,11 @@ async def upload_file(
             detail="At least one tag is required for file upload"
         )
     
-    file_content = await file.read()
-    file_size = len(file_content)
-    
-    from io import BytesIO
-    file_data = BytesIO(file_content)
+    file_size = file.size if file.size else 0
     
     file_metadata = await file_service.upload_file(
         file_name=file.filename,
-        file_data=file_data,
+        file_data=file.file,
         file_size=file_size,
         tags=tag_list,
         owner_id=current_user,


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the file upload flow in both the CLI and backend. The most significant changes include adding upload progress reporting and dynamic timeout calculation in the CLI, as well as streamlining file chunking and upload handling on the backend.

**CLI upload improvements:**
- Added dynamic upload timeout calculation based on file size to prevent premature timeouts on large files.
- Implemented upload progress reporting in the CLI, displaying the number of MB uploaded and percentage complete for each file.
- Improved error handling for connection and timeout errors during file upload, providing clearer messages and cleaning up the progress line on failure.

**Backend file upload and chunking changes:**
- Modified backend to stream file data during upload instead of reading the entire file into memory, improving efficiency for large files.
- Refactored the chunking logic to yield chunks instead of building a list in memory, further optimizing memory usage for large files. [[1]](diffhunk://#diff-1d389214844b6eab5155ff6efcd7e9cfe0a59cf6e7db8bd459530dfa47fae428L131-L134) [[2]](diffhunk://#diff-1d389214844b6eab5155ff6efcd7e9cfe0a59cf6e7db8bd459530dfa47fae428L153-L157)
- Adjusted logging and chunk metadata handling to reflect the new streaming approach and improve observability. [[1]](diffhunk://#diff-1d389214844b6eab5155ff6efcd7e9cfe0a59cf6e7db8bd459530dfa47fae428L65-R65) [[2]](diffhunk://#diff-1d389214844b6eab5155ff6efcd7e9cfe0a59cf6e7db8bd459530dfa47fae428L98-R103)