### PR TITLE
feat/download retry

### DIFF
--- a/cli/constants.py
+++ b/cli/constants.py
@@ -13,6 +13,7 @@ STYLE = Style.from_dict(
 
 RED_ORANGE = "\033[38;2;244;89;53m"
 GREEN = "\033[38;2;0;255;0m"
+YELLOW = "\033[38;2;255;255;0m"
 RESET = "\033[0m"
 
 LOGO = f"""{RED_ORANGE}
@@ -37,7 +38,7 @@ HELP_TEXT = """Available commands:
   list tag-query                      List files matching tag query (empty = all)
   add-tags tag-query tag-list         Add tags to files matching tag query
   delete-tags tag-query tag-list      Remove tags from files matching tag query
-  download <filename> [output_path]   Download file (output uses downloads/ prefix or defaults to downloads/)
+  download <filename> [output_path]   Download file (may take a moment in distributed environments)
   clear                               Clear screen and redisplay welcome message
   help                                Show this help
   exit                                Exit REPL


### PR DESCRIPTION
  Co-authored-by: LoLProM <mauriciosundejimenez@gmail.com>
  
This pull request improves the reliability and user experience of file downloads in both the CLI and backend service. The main changes include adding user feedback and progress indicators in the CLI during downloads, and implementing retry logic for chunk retrieval in the backend to handle transient failures and improve robustness.

**CLI improvements:**
- Added a yellow color constant and used it to display warnings and progress messages to the user. [[1]](diffhunk://#diff-a81f9bb0b9bf827866ceff4a9c1587d37581d7b78bcbb503ed34882cb085313eR16) [[2]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1L13-R13)
- Updated the help text to clarify that downloads may take longer in distributed environments.
- Enhanced the `download` command to display a warning if the download may take a moment, and to show progress or a "retrieving data..." message if the download stalls. [[1]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1R658-R659) [[2]](diffhunk://#diff-ffe5ef1c0cf6e315ca1652d169a3016ff9045275719075d72431e73e726876d1R670-R705)

**Backend reliability improvements:**
- Added retry logic when streaming file chunks in the backend service, with exponential backoff for both chunk not found and chunkserver unavailable errors. This helps handle transient issues and improves download reliability.
- Imported the new `ChunkserverUnavailableError` exception to support the improved error handling.